### PR TITLE
Add basic websocket networking support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 name = "eda3-ecs_wasm_game_soli_vanilla_codex_20250731"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -130,4 +142,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "WebSocket",
+    "MessageEvent",
+    "Event",
+    "ErrorEvent",
+    "BinaryType"
+] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ use wasm_bindgen::prelude::*;
 
 mod ecs;
 mod game;
+mod network;
 
 use ecs::World;
-use game::{Deck, Card};
+use game::{Card, Deck};
+use network::NetworkClient;
 
 /// High level game wrapper exposed to JavaScript.
 /// This struct owns the ECS `World` and a deck of cards.
@@ -12,6 +14,9 @@ use game::{Deck, Card};
 pub struct SolitaireGame {
     world: World,
     deck: Deck,
+    // Networking is optional. We create the socket lazily when the player
+    // decides to join a multiplayer session.
+    network: Option<NetworkClient>,
 }
 
 #[wasm_bindgen]
@@ -22,11 +27,32 @@ impl SolitaireGame {
         SolitaireGame {
             world: World::new(),
             deck: Deck::standard(),
+            network: None,
         }
     }
 
     /// Draw a card from the deck. Returns `None` when the deck is empty.
     pub fn draw_card(&mut self) -> Option<String> {
-        self.deck.cards.pop().map(|c| format!("{:?} of {:?}", c.rank, c.suit))
+        self.deck
+            .cards
+            .pop()
+            .map(|c| format!("{:?} of {:?}", c.rank, c.suit))
+    }
+
+    /// Connect to a multiplayer server using a WebSocket URL.
+    ///
+    /// Returns an error if the connection could not be established.
+    pub fn connect(&mut self, url: &str) -> Result<(), JsValue> {
+        let client = NetworkClient::new(url)?;
+        self.network = Some(client);
+        Ok(())
+    }
+
+    /// Send a text message over the WebSocket if it is connected.
+    pub fn send(&self, msg: &str) -> Result<(), JsValue> {
+        match &self.network {
+            Some(net) => net.send(msg),
+            None => Err(JsValue::from_str("Not connected")),
+        }
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,74 @@
+//! A small networking utility to communicate with a server via WebSockets.
+//!
+//! This module is written for educational purposes so every step is heavily
+//! commented. It exposes a `NetworkClient` that can be created from JavaScript
+//! using `wasm-bindgen`. The client wraps the browser's `WebSocket` API and
+//! allows sending text messages and registering callbacks for incoming
+//! messages or connection events.
+
+use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsCast, closure::Closure};
+use web_sys::{BinaryType, ErrorEvent, Event, MessageEvent, WebSocket};
+
+/// A very small wrapper around `WebSocket` so that we can use it from Rust
+/// and expose it to JavaScript through WebAssembly.
+#[wasm_bindgen]
+pub struct NetworkClient {
+    /// The underlying WebSocket handle provided by the browser.
+    ws: WebSocket,
+}
+
+#[wasm_bindgen]
+impl NetworkClient {
+    /// Create and connect to a WebSocket at the given URL.
+    ///
+    /// The constructor returns a `Result` because establishing the connection
+    /// might fail if the URL is invalid or the browser blocks it.
+    #[wasm_bindgen(constructor)]
+    pub fn new(url: &str) -> Result<NetworkClient, JsValue> {
+        let ws = WebSocket::new(url)?;
+        ws.set_binary_type(BinaryType::Arraybuffer);
+        Ok(NetworkClient { ws })
+    }
+
+    /// Send a UTF-8 text message to the server.
+    pub fn send(&self, msg: &str) -> Result<(), JsValue> {
+        self.ws.send_with_str(msg)
+    }
+
+    /// Set a callback that is invoked whenever a message is received.
+    ///
+    /// The callback receives the text of the message as its only argument.
+    pub fn on_message(&self, callback: &js_sys::Function) {
+        // Clone the function so it can be moved into the `Closure` and live
+        // for the entire lifetime of the websocket.
+        let cb_func = callback.clone();
+        let cb = Closure::<dyn FnMut(MessageEvent)>::wrap(Box::new(move |e| {
+            if let Ok(text) = e.data().dyn_into::<js_sys::JsString>() {
+                let _ = cb_func.call1(&JsValue::NULL, &text);
+            }
+        }));
+        self.ws.set_onmessage(Some(cb.as_ref().unchecked_ref()));
+        cb.forget();
+    }
+
+    /// Set a callback that fires when the socket is successfully opened.
+    pub fn on_open(&self, callback: &js_sys::Function) {
+        let cb_func = callback.clone();
+        let cb = Closure::<dyn FnMut(Event)>::wrap(Box::new(move |_| {
+            let _ = cb_func.call0(&JsValue::NULL);
+        }));
+        self.ws.set_onopen(Some(cb.as_ref().unchecked_ref()));
+        cb.forget();
+    }
+
+    /// Set a callback that fires if an error occurs with the connection.
+    pub fn on_error(&self, callback: &js_sys::Function) {
+        let cb_func = callback.clone();
+        let cb = Closure::<dyn FnMut(ErrorEvent)>::wrap(Box::new(move |e| {
+            let _ = cb_func.call1(&JsValue::NULL, &JsValue::from(e.message()));
+        }));
+        self.ws.set_onerror(Some(cb.as_ref().unchecked_ref()));
+        cb.forget();
+    }
+}


### PR DESCRIPTION
## Summary
- add WebSocket networking module using `web-sys`
- expose optional networking in `SolitaireGame`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688afa0a4fa08326845cdddf33ed541e